### PR TITLE
Add tasks analytics page with chart toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/App.jsx
+++ b/App.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import Home from './Home';
+import TasksAnalytics from './TasksAnalytics';
+
+const initialProjects = [
+  {
+    project_name: 'ออกแบบป้าย',
+    start_date: '2025-08-01',
+    planned_end_date: '2025-08-10',
+    completion: 0.75,
+    status: 'อยู่ระหว่างดำเนินการ',
+    tasks: ['ตั้งค่าโครงร่าง', 'ออกแบบสี', 'เตรียมไฟล์พิมพ์'],
+  },
+  {
+    project_name: 'Thai Travel Fair',
+    start_date: '2025-08-03',
+    planned_end_date: '2025-08-20',
+    completion: 1.0,
+    status: 'เสร็จสิ้น',
+    tasks: ['จองบูธ', 'สร้างแบนเนอร์ออนไลน์', 'จัดทำเอกสารนำเสนอ', 'ประสานงานผู้ขาย'],
+  },
+  {
+    project_name: 'รีแบรนด์ Café',
+    start_date: '2025-07-15',
+    planned_end_date: '2025-08-25',
+    completion: 0.5,
+    status: 'เกินกำหนด',
+    tasks: ['สำรวจตลาด'],
+  },
+];
+
+const App = () => {
+  const [page, setPage] = useState('dashboard');
+  const [projects, setProjects] = useState(initialProjects);
+
+  const addTask = (projectIdx) => {
+    setProjects((prev) => {
+      const updated = [...prev];
+      updated[projectIdx].tasks.push(`งานใหม่ ${updated[projectIdx].tasks.length + 1}`);
+      return updated;
+    });
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-48 bg-gray-800 text-white p-4 space-y-4">
+        <h2 className="text-xl font-bold">TEM</h2>
+        <nav className="space-y-2">
+          <button
+            onClick={() => setPage('dashboard')}
+            className={`block w-full text-left p-2 rounded ${page === 'dashboard' ? 'bg-gray-700' : ''}`}
+          >
+            Dashboard
+          </button>
+          <button
+            onClick={() => setPage('analytics')}
+            className={`block w-full text-left p-2 rounded ${page === 'analytics' ? 'bg-gray-700' : ''}`}
+          >
+            Analytics
+          </button>
+        </nav>
+      </aside>
+      <main className="flex-1 p-6">
+        {page === 'dashboard' && <Home projects={projects} addTask={addTask} />}
+        {page === 'analytics' && <TasksAnalytics projects={projects} />}
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/Home.jsx
+++ b/Home.jsx
@@ -4,40 +4,65 @@ import ProjectStatusPie from './ProjectStatusPie';
 import ProjectTable from './ProjectTable';
 import TeamLeaderboard from './TeamLeaderboard';
 
-const dummyProjects = [
-  { project_name: 'ออกแบบป้าย', start_date: '2025-08-01', planned_end_date: '2025-08-10', completion: 0.75, status: 'อยู่ระหว่างดำเนินการ' },
-  { project_name: 'Thai Travel Fair', start_date: '2025-08-03', planned_end_date: '2025-08-20', completion: 1.0, status: 'เสร็จสิ้น' },
-  { project_name: 'รีแบรนด์ Café', start_date: '2025-07-15', planned_end_date: '2025-08-25', completion: 0.5, status: 'เกินกำหนด' },
-];
-
 const dummyTeam = [
   { name: 'ไฟฟ้า', tasks_completed: 14 },
   { name: 'บีม', tasks_completed: 9 },
   { name: 'แอน', tasks_completed: 6 },
 ];
 
-const Home = () => {
+const Home = ({ projects, addTask }) => {
+  const totalProjects = projects.length;
+  const inProgress = projects.filter(
+    (p) => p.status === 'อยู่ระหว่างดำเนินการ'
+  ).length;
+  const completed = projects.filter((p) => p.status === 'เสร็จสิ้น').length;
+  const statusCounts = [
+    inProgress,
+    completed,
+    projects.filter((p) => p.status === 'เกินกำหนด').length,
+  ];
+
   return (
     <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
       <h1 className="text-2xl font-bold">📊 Dashboard</h1>
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <DashboardCard title="โปรเจกต์ทั้งหมด" value="12" color="bg-blue-600" />
-        <DashboardCard title="กำลังดำเนินการ" value="5" color="bg-yellow-500" />
-        <DashboardCard title="เสร็จสิ้น" value="7" color="bg-green-500" />
+        <DashboardCard title="โปรเจกต์ทั้งหมด" value={totalProjects} color="bg-blue-600" />
+        <DashboardCard title="กำลังดำเนินการ" value={inProgress} color="bg-yellow-500" />
+        <DashboardCard title="เสร็จสิ้น" value={completed} color="bg-green-500" />
       </div>
 
       {/* Pie Chart + Leaderboard */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <ProjectStatusPie data={[5, 3, 2]} />
+        <ProjectStatusPie data={statusCounts} labels={['กำลังดำเนินการ','เสร็จสิ้น','เกินกำหนด']} />
         <TeamLeaderboard teamData={dummyTeam} />
       </div>
 
       {/* Table of Projects */}
       <div className="mt-8">
         <h2 className="text-xl font-semibold mb-2">📁 รายชื่อโปรเจกต์</h2>
-        <ProjectTable projects={dummyProjects} />
+        <ProjectTable projects={projects} />
+      </div>
+
+      {/* Task Controls */}
+      <div className="mt-8">
+        <h2 className="text-xl font-semibold mb-2">🛠️ จัดการงาน</h2>
+        <ul className="space-y-2">
+          {projects.map((project, idx) => (
+            <li key={idx} className="flex items-center">
+              <span className="flex-1">
+                {project.project_name}: {project.tasks.length} tasks
+              </span>
+              <button
+                onClick={() => addTask(idx)}
+                className="px-2 py-1 bg-blue-600 text-white rounded"
+              >
+                Add Task
+              </button>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );

--- a/ProjectStatusPie.jsx
+++ b/ProjectStatusPie.jsx
@@ -4,9 +4,9 @@ import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-const ProjectStatusPie = ({ data }) => {
+const ProjectStatusPie = ({ data, labels = ['On Track', 'At Risk', 'Off Track'] }) => {
   const chartData = {
-    labels: ['On Track', 'At Risk', 'Off Track'],
+    labels,
     datasets: [
       {
         label: 'Projects',

--- a/TasksAnalytics.jsx
+++ b/TasksAnalytics.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar, Line } from 'react-chartjs-2';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend
+);
+
+const TasksAnalytics = ({ projects }) => {
+  const [chartType, setChartType] = useState('bar');
+
+  const labels = projects.map((p) => p.project_name);
+  const dataValues = projects.map((p) => p.tasks.length);
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Tasks',
+        data: dataValues,
+        backgroundColor: '#3B82F6',
+        borderColor: '#3B82F6',
+        fill: false,
+      },
+    ],
+  };
+
+  const ChartComponent = chartType === 'bar' ? Bar : Line;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">📈 Tasks per Project</h1>
+        <button
+          onClick={() => setChartType(chartType === 'bar' ? 'line' : 'bar')}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Switch to {chartType === 'bar' ? 'Line' : 'Bar'} Chart
+        </button>
+      </div>
+      <ChartComponent data={chartData} />
+    </div>
+  );
+};
+
+export default TasksAnalytics;

--- a/index.jsx
+++ b/index.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import Home from "./Home";
+import App from "./App";
 import "./style.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Home />
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add `App` shell with sidebar navigation and shared project state
- Introduce `TasksAnalytics` page that charts task counts per project with bar/line toggle
- Update `Home` dashboard to consume shared projects and manage tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad6c36c6ec8325a00e9c972da85f91