### PR TITLE
Optimize dashboard for mobile view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/Home.jsx
+++ b/Home.jsx
@@ -18,18 +18,18 @@ const dummyTeam = [
 
 const Home = () => {
   return (
-    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
-      <h1 className="text-2xl font-bold">📊 Dashboard</h1>
+    <div className="p-4 space-y-6 bg-gray-50 min-h-screen">
+      <h1 className="text-xl font-bold">📊 Dashboard</h1>
 
       {/* Summary Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         <DashboardCard title="โปรเจกต์ทั้งหมด" value="12" color="bg-blue-600" />
         <DashboardCard title="กำลังดำเนินการ" value="5" color="bg-yellow-500" />
         <DashboardCard title="เสร็จสิ้น" value="7" color="bg-green-500" />
       </div>
 
       {/* Pie Chart + Leaderboard */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div className="hidden md:grid md:grid-cols-2 gap-6">
         <ProjectStatusPie data={[5, 3, 2]} />
         <TeamLeaderboard teamData={dummyTeam} />
       </div>

--- a/ProjectTable.jsx
+++ b/ProjectTable.jsx
@@ -2,37 +2,68 @@ import React from 'react';
 
 const ProjectTable = ({ projects }) => {
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full table-auto border border-gray-200">
-        <thead className="bg-gray-100 text-left text-sm font-semibold">
-          <tr>
-            <th className="p-2">Project</th>
-            <th className="p-2">Start</th>
-            <th className="p-2">End</th>
-            <th className="p-2">Progress</th>
-            <th className="p-2">Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {projects.map((project, idx) => (
-            <tr key={idx} className="border-t">
-              <td className="p-2">{project.project_name}</td>
-              <td className="p-2">{project.start_date}</td>
-              <td className="p-2">{project.planned_end_date}</td>
-              <td className="p-2">{Math.round(project.completion * 100)}%</td>
-              <td className="p-2">
-                <span className={
-                  project.status.includes('เสร็จ') ? 'text-green-600' :
-                  project.status.includes('เกิน') ? 'text-red-500' :
-                  'text-yellow-500'
-                }>
-                  {project.status}
-                </span>
-              </td>
+    <div>
+      {/* Mobile list view */}
+      <div className="space-y-4 md:hidden">
+        {projects.map((project, idx) => (
+          <div key={idx} className="p-4 border rounded-lg shadow-sm">
+            <div className="font-semibold">{project.project_name}</div>
+            <div className="text-sm text-gray-600">
+              {project.start_date} - {project.planned_end_date}
+            </div>
+            <div className="text-sm">Progress: {Math.round(project.completion * 100)}%</div>
+            <div
+              className={`text-sm ${
+                project.status.includes('เสร็จ')
+                  ? 'text-green-600'
+                  : project.status.includes('เกิน')
+                  ? 'text-red-500'
+                  : 'text-yellow-500'
+              }`}
+            >
+              {project.status}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop table view */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full table-auto border border-gray-200">
+          <thead className="bg-gray-100 text-left text-sm font-semibold">
+            <tr>
+              <th className="p-2">Project</th>
+              <th className="p-2">Start</th>
+              <th className="p-2">End</th>
+              <th className="p-2">Progress</th>
+              <th className="p-2">Status</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {projects.map((project, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="p-2">{project.project_name}</td>
+                <td className="p-2">{project.start_date}</td>
+                <td className="p-2">{project.planned_end_date}</td>
+                <td className="p-2">{Math.round(project.completion * 100)}%</td>
+                <td className="p-2">
+                  <span
+                    className={
+                      project.status.includes('เสร็จ')
+                        ? 'text-green-600'
+                        : project.status.includes('เกิน')
+                        ? 'text-red-500'
+                        : 'text-yellow-500'
+                    }
+                  >
+                    {project.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- adjust dashboard layout for smaller screens and hide charts on mobile
- add mobile-friendly card view for project list
- ignore node_modules and dist build output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae19a7bb9c8325b3fd4087a8407541